### PR TITLE
Copy button appears centered over text (rather than centered over label)

### DIFF
--- a/CopyableLabel.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CopyableLabel.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
@@ -22,23 +22,67 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CopyableLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eAE-XX-87R">
-                                <rect key="frame" x="130.5" y="323" width="114" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Top CopyableLabel" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eAE-XX-87R" userLabel="Top Copyable Label">
+                                <rect key="frame" x="114.5" y="221" width="146.5" height="21"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="copyable" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Left CopyableLabel" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DqN-Mt-UqU" userLabel="Left Copyable Label">
+                                <rect key="frame" x="37.5" y="272" width="300" height="21"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="copyable" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Center CopyableLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AYz-Ax-ki7">
+                                <rect key="frame" x="37.5" y="323" width="300" height="21"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="copyable" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Right CopyableLabel" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iMT-me-Zqb">
+                                <rect key="frame" x="37.5" y="374" width="300" height="21"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="copyable" value="YES"/>
+                                </userDefinedRuntimeAttributes>
                             </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="eAE-XX-87R" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Qwq-Xa-zST"/>
-                            <constraint firstItem="eAE-XX-87R" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="j1g-P2-mAY"/>
+                            <constraint firstItem="iMT-me-Zqb" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.8" id="1FF-Zn-Jib"/>
+                            <constraint firstItem="DqN-Mt-UqU" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="5An-sn-GKP"/>
+                            <constraint firstItem="AYz-Ax-ki7" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="80P-jK-EUj"/>
+                            <constraint firstItem="DqN-Mt-UqU" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.8" id="DwS-B6-58b"/>
+                            <constraint firstItem="iMT-me-Zqb" firstAttribute="top" secondItem="AYz-Ax-ki7" secondAttribute="bottom" constant="30" id="EhC-i3-aMT"/>
+                            <constraint firstItem="eAE-XX-87R" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Fwf-PD-Fo5"/>
+                            <constraint firstItem="AYz-Ax-ki7" firstAttribute="top" secondItem="DqN-Mt-UqU" secondAttribute="bottom" constant="30" id="O5N-m4-gc5"/>
+                            <constraint firstItem="AYz-Ax-ki7" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.8" id="RaJ-DY-fx3"/>
+                            <constraint firstItem="iMT-me-Zqb" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="jQH-ya-Gn3"/>
+                            <constraint firstItem="eAE-XX-87R" firstAttribute="bottom" secondItem="DqN-Mt-UqU" secondAttribute="top" constant="-30" id="kQC-VL-17L"/>
+                            <constraint firstItem="AYz-Ax-ki7" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="oxS-CF-u4s"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="copyableLabel" destination="eAE-XX-87R" id="pjb-EA-dYB"/>
                     </connections>
                 </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>
     </scenes>

--- a/Source/CopyableLabel.swift
+++ b/Source/CopyableLabel.swift
@@ -59,12 +59,12 @@ extension UILabel {
 
         becomeFirstResponder()
 
-        print("woot yo")
-        if let targetRect = self.boundingRect() {
-            copyMenu.setTargetRect(targetRect, in: self)
+        if let rect = self.textBoundingRect() {
+            copyMenu.setTargetRect(rect, in: self)
         } else {
             copyMenu.setTargetRect(bounds, in: self)
         }
+        
         copyMenu.setMenuVisible(true, animated: true)
     }
 
@@ -89,25 +89,26 @@ extension UILabel {
 }
 
 extension UILabel {
-    func boundingRect() -> CGRect? {
+    func textBoundingRect() -> CGRect? {
         
         guard let attributedText = attributedText else { return nil }
         
         let range = NSMakeRange(0, attributedText.length)
         
         let textStorage = NSTextStorage(attributedString: attributedText)
+        
         let layoutManager = NSLayoutManager()
         
         textStorage.addLayoutManager(layoutManager)
         
         let textContainer = NSTextContainer(size: bounds.size)
+        
         textContainer.lineFragmentPadding = 0.0
         
         layoutManager.addTextContainer(textContainer)
         
         var glyphRange = NSRange()
         
-        // Convert the range for glyphs.
         layoutManager.characterRange(forGlyphRange: range, actualGlyphRange: &glyphRange)
         
         return layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)

--- a/Source/CopyableLabel.swift
+++ b/Source/CopyableLabel.swift
@@ -59,12 +59,10 @@ extension UILabel {
 
         becomeFirstResponder()
 
-        if let rect = self.textBoundingRect() {
-            copyMenu.setTargetRect(rect, in: self)
-        } else {
-            copyMenu.setTargetRect(bounds, in: self)
-        }
-        
+        let rect = self.textRect(forBounds: self.bounds, limitedToNumberOfLines: 0)
+
+        copyMenu.setTargetRect(rect, in:self)
+
         copyMenu.setMenuVisible(true, animated: true)
     }
 
@@ -84,30 +82,5 @@ extension UILabel {
 
     override open func copy(_ sender: Any?) {
         UIPasteboard.general.string = text
-    }
-    
-    func textBoundingRect() -> CGRect? {
-        
-        guard let attributedText = attributedText else { return nil }
-        
-        let range = NSMakeRange(0, attributedText.length)
-        
-        let textStorage = NSTextStorage(attributedString: attributedText)
-        
-        let layoutManager = NSLayoutManager()
-        
-        textStorage.addLayoutManager(layoutManager)
-        
-        let textContainer = NSTextContainer(size: bounds.size)
-        
-        textContainer.lineFragmentPadding = 0.0
-        
-        layoutManager.addTextContainer(textContainer)
-        
-        var glyphRange = NSRange()
-        
-        layoutManager.characterRange(forGlyphRange: range, actualGlyphRange: &glyphRange)
-        
-        return layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
     }
 }

--- a/Source/CopyableLabel.swift
+++ b/Source/CopyableLabel.swift
@@ -86,9 +86,6 @@ extension UILabel {
         UIPasteboard.general.string = text
     }
     
-}
-
-extension UILabel {
     func textBoundingRect() -> CGRect? {
         
         guard let attributedText = attributedText else { return nil }

--- a/Source/CopyableLabel.swift
+++ b/Source/CopyableLabel.swift
@@ -59,7 +59,12 @@ extension UILabel {
 
         becomeFirstResponder()
 
-        copyMenu.setTargetRect(bounds, in: self)
+        print("woot yo")
+        if let targetRect = self.boundingRect() {
+            copyMenu.setTargetRect(targetRect, in: self)
+        } else {
+            copyMenu.setTargetRect(bounds, in: self)
+        }
         copyMenu.setMenuVisible(true, animated: true)
     }
 
@@ -81,4 +86,30 @@ extension UILabel {
         UIPasteboard.general.string = text
     }
     
+}
+
+extension UILabel {
+    func boundingRect() -> CGRect? {
+        
+        guard let attributedText = attributedText else { return nil }
+        
+        let range = NSMakeRange(0, attributedText.length)
+        
+        let textStorage = NSTextStorage(attributedString: attributedText)
+        let layoutManager = NSLayoutManager()
+        
+        textStorage.addLayoutManager(layoutManager)
+        
+        let textContainer = NSTextContainer(size: bounds.size)
+        textContainer.lineFragmentPadding = 0.0
+        
+        layoutManager.addTextContainer(textContainer)
+        
+        var glyphRange = NSRange()
+        
+        // Convert the range for glyphs.
+        layoutManager.characterRange(forGlyphRange: range, actualGlyphRange: &glyphRange)
+        
+        return layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+    }
 }


### PR DESCRIPTION
I added an extension to UILabel to find the bounding box of the text in the label.  The bounding box is then used as the rect for the call to copyMenu.setTargetRect

I added a few labels to the example to illustrate.

Hope this is helpful!