### PR TITLE
Add copyableLabelDidShowCopyMenu notification

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -9,7 +9,26 @@ class ViewController: UIViewController {
         super.viewDidLoad()
 
         copyableLabel.copyable = true
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(didShowCopyMenu(_:)), name: .copyableLabelDidShowCopyMenu, object: nil)
     }
 
+    @objc func didShowCopyMenu(_ notification:NSNotification) {
+        // Optionally register for copy didHide notification
+    NotificationCenter.default.addObserver(self, selector: #selector(didHideCopyMenu(_:)), name: Notification.Name.UIMenuControllerDidHideMenu, object: nil)
+        
+        if let copyingText = notification.object as? UILabel {
+            print(copyingText.text)
+            let rect = notification.userInfo!["rect"] as! CGRect
+            print(rect)
+            // Do interesting stuff
+        }
+    }
+    
+    @objc func didHideCopyMenu(_ notification:NSNotification) {
+        // Probably best to un-register for this notification
+        NotificationCenter.default.removeObserver(self, name: .UIMenuControllerDidHideMenu, object: nil)
+        // Do interesting stuff
+    }
 }
 

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -18,9 +18,7 @@ class ViewController: UIViewController {
     NotificationCenter.default.addObserver(self, selector: #selector(didHideCopyMenu(_:)), name: Notification.Name.UIMenuControllerDidHideMenu, object: nil)
         
         if let copyingText = notification.object as? UILabel {
-            print(copyingText.text)
-            let rect = notification.userInfo!["rect"] as! CGRect
-            print(rect)
+            print(copyingText.text as Any)
             // Do interesting stuff
         }
     }

--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@ If another object (e.g. UIViewController) has a need to know which CopyableLabel
 NotificationCenter.default.addObserver(self, selector: #selector(receivedCopyableLabelNotification(_:)), name: .copyableLabelDidShowCopyMenu, object: nil)
 ```
 
-The registering object will receive a Notification that contains a reference to the CopyableLabel that posted the notification and the notification's userInfo dictionary will contain an entry "rect" referencing the rectangle used to display the Copy menu.
+The registering object will receive a Notification that contains a reference to the CopyableLabel that posted the notification.
 
 ```
 @objc func receivedCopyableLabelNotification(_ notification:NSNotification) {
 	if let label = notification.object as? UILabel {
 		print(label.text!)
 	}
-	print(notification.userInfo?["rect"] ?? "empty")     
-	// Do other interesting UI stuff here
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,30 @@ let label = UILabel()
 label.copyable = true
 ```
 
-Or set copyable property to true in Interface Builder.
+Or set copyable property to true in Interface Builder.  
+
+If another object (e.g. UIViewController) has a need to know which CopyableLabel has invoked the UIMenuController (i.e. presented the 'Copy' balloon, register the object for `Notification.name.copyableLabelDidShowCopyMenu` notification:
+
+```
+NotificationCenter.default.addObserver(self, selector: #selector(receivedCopyableLabelNotification(_:)), name: .copyableLabelDidShowCopyMenu, object: nil)
+```
+
+The registering object will receive a Notification that contains a reference to the CopyableLabel that posted the notification and the notification's userInfo dictionary will contain an entry "rect" referencing the rectangle used to display the Copy menu.
+
+```
+@objc func receivedCopyableLabelNotification(_ notification:NSNotification) {
+	if let label = notification.object as? UILabel {
+		print(label.text!)
+	}
+	print(notification.userInfo?["rect"] ?? "empty")     
+	// Do other interesting UI stuff here
+}
+```
+
+UIMenuController does post a UIMenuController.didShowMenuNotification, however that notification does not provide any additional information (i.e. which UI elemement posted the notification, where the menu is, etc.).  
+
+Register for the UIMenuController willHide or didHide notifications, if you need to know when the menu is dismissed.
+
 
 ## Requirements
 

--- a/Source/CopyableLabel.swift
+++ b/Source/CopyableLabel.swift
@@ -61,6 +61,9 @@ extension UILabel {
 
         copyMenu.setTargetRect(bounds, in: self)
         copyMenu.setMenuVisible(true, animated: true)
+        
+        NotificationCenter.default.post(name: .copyableLabelDidShowCopyMenu, object: self, userInfo: ["rect":bounds])
+
     }
 
     override open var canBecomeFirstResponder : Bool {
@@ -81,4 +84,8 @@ extension UILabel {
         UIPasteboard.general.string = text
     }
     
+}
+
+extension Notification.Name {
+    public static let copyableLabelDidShowCopyMenu = Notification.Name("copyableLabelDidShowCopyMenu")
 }

--- a/Source/CopyableLabel.swift
+++ b/Source/CopyableLabel.swift
@@ -62,8 +62,7 @@ extension UILabel {
         copyMenu.setTargetRect(bounds, in: self)
         copyMenu.setMenuVisible(true, animated: true)
         
-        NotificationCenter.default.post(name: .copyableLabelDidShowCopyMenu, object: self, userInfo: ["rect":bounds])
-
+        NotificationCenter.default.post(name: .copyableLabelDidShowCopyMenu, object: self, userInfo: nil)
     }
 
     override open var canBecomeFirstResponder : Bool {


### PR DESCRIPTION
Adds a copyableLabelDidShowCopyMenu notification that is posted when the copy menu appears.  The notification includes a reference to the CopyableLabel.